### PR TITLE
[refactor] 이미지 이름 enum화

### DIFF
--- a/LullabyRecipe/Utilities/Static.swift
+++ b/LullabyRecipe/Utilities/Static.swift
@@ -86,6 +86,22 @@ enum ColorPalette {
     }
 }
 
+enum ImageName {
+    case BackPattern
+    case NewSoundtrack
+    
+    var imageName: String {
+        get {
+            switch self {
+            case .BackPattern:
+                return "BackPattern"
+            case .NewSoundtrack:
+                return "NewSoundtrack"
+            }
+        }
+    }
+}
+
 let recipeRandomName = ["Recipe1","Recipe2","Recipe3","Recipe4","Recipe5","Recipe6","Recipe7","Recipe8","Recipe9","Recipe10"]
 
 

--- a/LullabyRecipe/Views/Home/Home.swift
+++ b/LullabyRecipe/Views/Home/Home.swift
@@ -88,7 +88,7 @@ struct Home: View {
     
     @ViewBuilder
     func MainBanner() -> some View {
-        Image("NewSoundtrack")
+        Image(ImageName.NewSoundtrack.imageName)
             .resizable()
             .overlay(
                 VStack {

--- a/LullabyRecipe/Views/Onboarding/OnBoarding.swift
+++ b/LullabyRecipe/Views/Onboarding/OnBoarding.swift
@@ -16,7 +16,7 @@ struct OnBoarding: View {
         ZStack {
             ColorPalette.launchbackground.color.ignoresSafeArea()
             
-            Image("BackPattern")
+            Image(ImageName.BackPattern.imageName)
                 .resizable()
                 .ignoresSafeArea()
             


### PR DESCRIPTION
## 작업한내용
- image("abide")의 형태로 하드코딩된 것들 enum화
- BackPattern, NewSoundtrack  두 개발견하여 ImageName enum을 만들어 정리
## 리뷰가 필요한 부분
- image("  검색한 결과 BackPattern, NewSoundtrack 두 개 발견하여 enum화 하였습니다. 이때 enum을 ImageName으로 뭉뚱그려서 만들었는데 뷰 단위의 구분이 필요한지 궁금합니다. 지금은 두 개밖에 없는 것 같아서 일단 하나의 enum에 넣었습니다.
## 질문할 내용
- enum의 명칭과 내부의 프로퍼티의 명칭이 비슷하거나 똑같고 return 타입이 똑같은 경우 rawValue로 처리해도 좋을까요? 
- 예상되는 변화 : 코드길이가 줄어듬..
```
enum ImageName: String {
    case BackPattern = "BackPattern"
    case NewSoundtrack = "NewSoundtrack"
}

//
Image(ImageName.NewSoundtrack.rawValue)
```
