### PR TITLE
[feat] #44 : 워치와 iOS 사이에 데이터 주고받기

### DIFF
--- a/LullabyRecipe.xcodeproj/project.pbxproj
+++ b/LullabyRecipe.xcodeproj/project.pbxproj
@@ -7,7 +7,24 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21022416287EBC390008843E /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21022415287EBC390008843E /* PlayerView.swift */; };
+		21180BA2287EACE8005ED3AF /* MixedSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AB2866F20A007CCAE9 /* MixedSound.swift */; };
+		21180BA3287EACEB005ED3AF /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE61B1283A8E1700F25769 /* Sound.swift */; };
+		211C6C3F287E3DE40018C8BC /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211C6C3E287E3DE40018C8BC /* ListView.swift */; };
+		211EA71B287A5FDA008BAD8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 211EA71A287A5FDA008BAD8D /* Assets.xcassets */; };
+		211EA721287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 211EA720287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		211EA726287A5FDA008BAD8D /* LullabyRecipeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211EA725287A5FDA008BAD8D /* LullabyRecipeApp.swift */; };
+		211EA72A287A5FDA008BAD8D /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211EA729287A5FDA008BAD8D /* NotificationController.swift */; };
+		211EA72C287A5FDA008BAD8D /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211EA72B287A5FDA008BAD8D /* NotificationView.swift */; };
+		211EA72E287A5FDA008BAD8D /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211EA72D287A5FDA008BAD8D /* ComplicationController.swift */; };
+		211EA730287A5FDA008BAD8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 211EA72F287A5FDA008BAD8D /* Assets.xcassets */; };
+		211EA733287A5FDA008BAD8D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 211EA732287A5FDA008BAD8D /* Preview Assets.xcassets */; };
+		211EA738287A5FDA008BAD8D /* WatchLullabyRecipe.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 211EA718287A5FD9008BAD8D /* WatchLullabyRecipe.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		211EA744287A6207008BAD8D /* Static.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DE1031283DF6E7002CDB9F /* Static.swift */; };
 		2150BD0F2876CB89006C8312 /* CustomTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2150BD0E2876CB89006C8312 /* CustomTabView.swift */; };
+		21ABB2F6287C662F00BE4117 /* ViewModelPhone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ABB2F5287C662F00BE4117 /* ViewModelPhone.swift */; };
+		21ABB2F8287C665B00BE4117 /* ViewModelWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ABB2F7287C665B00BE4117 /* ViewModelWatch.swift */; };
+		21ABB2FB287C6B1000BE4117 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211EA727287A5FDA008BAD8D /* ContentView.swift */; };
 		4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AB2866F20A007CCAE9 /* MixedSound.swift */; };
 		4A5769AE2866F44E007CCAE9 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AD2866F44E007CCAE9 /* DummyData.swift */; };
 		4A5769B02866F6B5007CCAE9 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5769AF2866F6B5007CCAE9 /* UserDefaultsManager.swift */; };
@@ -51,6 +68,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		211EA722287A5FDA008BAD8D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 58DE61772839C13900F25769 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 211EA71F287A5FDA008BAD8D;
+			remoteInfo = "WatchLullabyRecipe WatchKit Extension";
+		};
+		211EA736287A5FDA008BAD8D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 58DE61772839C13900F25769 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 211EA717287A5FD9008BAD8D;
+			remoteInfo = WatchLullabyRecipe;
+		};
 		58DE61902839C13B00F25769 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 58DE61772839C13900F25769 /* Project object */;
@@ -67,8 +98,49 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		211EA739287A5FDA008BAD8D /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				211EA738287A5FDA008BAD8D /* WatchLullabyRecipe.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		211EA73C287A5FDA008BAD8D /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				211EA721287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		21022415287EBC390008843E /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		211C6C3E287E3DE40018C8BC /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		211EA718287A5FD9008BAD8D /* WatchLullabyRecipe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WatchLullabyRecipe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		211EA71A287A5FDA008BAD8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		211EA720287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "WatchLullabyRecipe WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		211EA725287A5FDA008BAD8D /* LullabyRecipeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LullabyRecipeApp.swift; path = "WatchLullabyRecipe WatchKit Extension/LullabyRecipeApp.swift"; sourceTree = SOURCE_ROOT; };
+		211EA727287A5FDA008BAD8D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ContentView.swift; path = "WatchLullabyRecipe WatchKit Extension/ContentView.swift"; sourceTree = SOURCE_ROOT; };
+		211EA729287A5FDA008BAD8D /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotificationController.swift; path = "WatchLullabyRecipe WatchKit Extension/NotificationController.swift"; sourceTree = SOURCE_ROOT; };
+		211EA72B287A5FDA008BAD8D /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotificationView.swift; path = "WatchLullabyRecipe WatchKit Extension/NotificationView.swift"; sourceTree = SOURCE_ROOT; };
+		211EA72D287A5FDA008BAD8D /* ComplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ComplicationController.swift; path = "WatchLullabyRecipe WatchKit Extension/ComplicationController.swift"; sourceTree = SOURCE_ROOT; };
+		211EA72F287A5FDA008BAD8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = "WatchLullabyRecipe WatchKit Extension/Assets.xcassets"; sourceTree = SOURCE_ROOT; };
+		211EA732287A5FDA008BAD8D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "Preview Assets.xcassets"; path = "WatchLullabyRecipe WatchKit Extension/Preview Content/Preview Assets.xcassets"; sourceTree = SOURCE_ROOT; };
+		211EA734287A5FDA008BAD8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "WatchLullabyRecipe WatchKit Extension/Info.plist"; sourceTree = SOURCE_ROOT; };
+		211EA735287A5FDA008BAD8D /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; name = PushNotificationPayload.apns; path = "WatchLullabyRecipe WatchKit Extension/PushNotificationPayload.apns"; sourceTree = SOURCE_ROOT; };
 		2150BD0E2876CB89006C8312 /* CustomTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabView.swift; sourceTree = "<group>"; };
+		21ABB2F5287C662F00BE4117 /* ViewModelPhone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelPhone.swift; sourceTree = "<group>"; };
+		21ABB2F7287C665B00BE4117 /* ViewModelWatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelWatch.swift; sourceTree = "<group>"; };
 		4A5769AB2866F20A007CCAE9 /* MixedSound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedSound.swift; sourceTree = "<group>"; };
 		4A5769AD2866F44E007CCAE9 /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
 		4A5769AF2866F6B5007CCAE9 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
@@ -116,6 +188,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		211EA71D287A5FDA008BAD8D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		58DE617C2839C13900F25769 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -140,6 +219,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		211EA719287A5FD9008BAD8D /* WatchLullabyRecipe */ = {
+			isa = PBXGroup;
+			children = (
+				211EA71A287A5FDA008BAD8D /* Assets.xcassets */,
+			);
+			path = WatchLullabyRecipe;
+			sourceTree = "<group>";
+		};
+		211EA724287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension */ = {
+			isa = PBXGroup;
+			children = (
+				211EA725287A5FDA008BAD8D /* LullabyRecipeApp.swift */,
+				211EA727287A5FDA008BAD8D /* ContentView.swift */,
+				211EA729287A5FDA008BAD8D /* NotificationController.swift */,
+				211EA72B287A5FDA008BAD8D /* NotificationView.swift */,
+				211EA72D287A5FDA008BAD8D /* ComplicationController.swift */,
+				211EA72F287A5FDA008BAD8D /* Assets.xcassets */,
+				211EA734287A5FDA008BAD8D /* Info.plist */,
+				211EA735287A5FDA008BAD8D /* PushNotificationPayload.apns */,
+				211EA731287A5FDA008BAD8D /* Preview Content */,
+				21ABB2F7287C665B00BE4117 /* ViewModelWatch.swift */,
+				211C6C3E287E3DE40018C8BC /* ListView.swift */,
+				21022415287EBC390008843E /* PlayerView.swift */,
+			);
+			path = "WatchLullabyRecipe WatchKit Extension";
+			sourceTree = "<group>";
+		};
+		211EA731287A5FDA008BAD8D /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				211EA732287A5FDA008BAD8D /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		583AA0EF284E0344005A0677 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -247,6 +361,8 @@
 				58DE61812839C13900F25769 /* LullabyRecipe */,
 				58DE61922839C13B00F25769 /* LullabyRecipeTests */,
 				58DE619C2839C13B00F25769 /* LullabyRecipeUITests */,
+				211EA719287A5FD9008BAD8D /* WatchLullabyRecipe */,
+				211EA724287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension */,
 				58DE61802839C13900F25769 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -257,6 +373,8 @@
 				58DE617F2839C13900F25769 /* LullabyRecipe.app */,
 				58DE618F2839C13B00F25769 /* LullabyRecipeTests.xctest */,
 				58DE61992839C13B00F25769 /* LullabyRecipeUITests.xctest */,
+				211EA718287A5FD9008BAD8D /* WatchLullabyRecipe.app */,
+				211EA720287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -275,6 +393,7 @@
 				58DE61862839C13A00F25769 /* Assets.xcassets */,
 				58DE61C12841C20A00F25769 /* Launch Screen.storyboard */,
 				58DE61882839C13A00F25769 /* Preview Content */,
+				21ABB2F5287C662F00BE4117 /* ViewModelPhone.swift */,
 			);
 			path = LullabyRecipe;
 			sourceTree = "<group>";
@@ -330,6 +449,40 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		211EA717287A5FD9008BAD8D /* WatchLullabyRecipe */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 211EA740287A5FDA008BAD8D /* Build configuration list for PBXNativeTarget "WatchLullabyRecipe" */;
+			buildPhases = (
+				211EA716287A5FD9008BAD8D /* Resources */,
+				211EA73C287A5FDA008BAD8D /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				211EA723287A5FDA008BAD8D /* PBXTargetDependency */,
+			);
+			name = WatchLullabyRecipe;
+			productName = WatchLullabyRecipe;
+			productReference = 211EA718287A5FD9008BAD8D /* WatchLullabyRecipe.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		211EA71F287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 211EA73F287A5FDA008BAD8D /* Build configuration list for PBXNativeTarget "WatchLullabyRecipe WatchKit Extension" */;
+			buildPhases = (
+				211EA71C287A5FDA008BAD8D /* Sources */,
+				211EA71D287A5FDA008BAD8D /* Frameworks */,
+				211EA71E287A5FDA008BAD8D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "WatchLullabyRecipe WatchKit Extension";
+			productName = "WatchLullabyRecipe WatchKit Extension";
+			productReference = 211EA720287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
 		58DE617E2839C13900F25769 /* LullabyRecipe */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58DE61A32839C13B00F25769 /* Build configuration list for PBXNativeTarget "LullabyRecipe" */;
@@ -337,10 +490,12 @@
 				58DE617B2839C13900F25769 /* Sources */,
 				58DE617C2839C13900F25769 /* Frameworks */,
 				58DE617D2839C13900F25769 /* Resources */,
+				211EA739287A5FDA008BAD8D /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				211EA737287A5FDA008BAD8D /* PBXTargetDependency */,
 			);
 			name = LullabyRecipe;
 			productName = LullabyRecipe;
@@ -390,9 +545,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1340;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
+					211EA717287A5FD9008BAD8D = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					211EA71F287A5FDA008BAD8D = {
+						CreatedOnToolsVersion = 13.3;
+					};
 					58DE617E2839C13900F25769 = {
 						CreatedOnToolsVersion = 13.4;
 					};
@@ -422,11 +583,30 @@
 				58DE617E2839C13900F25769 /* LullabyRecipe */,
 				58DE618E2839C13B00F25769 /* LullabyRecipeTests */,
 				58DE61982839C13B00F25769 /* LullabyRecipeUITests */,
+				211EA717287A5FD9008BAD8D /* WatchLullabyRecipe */,
+				211EA71F287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		211EA716287A5FD9008BAD8D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				211EA71B287A5FDA008BAD8D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		211EA71E287A5FDA008BAD8D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				211EA733287A5FDA008BAD8D /* Preview Assets.xcassets in Resources */,
+				211EA730287A5FDA008BAD8D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		58DE617D2839C13900F25769 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -469,6 +649,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		211EA71C287A5FDA008BAD8D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				211C6C3F287E3DE40018C8BC /* ListView.swift in Sources */,
+				211EA72A287A5FDA008BAD8D /* NotificationController.swift in Sources */,
+				211EA72E287A5FDA008BAD8D /* ComplicationController.swift in Sources */,
+				21022416287EBC390008843E /* PlayerView.swift in Sources */,
+				21ABB2FB287C6B1000BE4117 /* ContentView.swift in Sources */,
+				211EA726287A5FDA008BAD8D /* LullabyRecipeApp.swift in Sources */,
+				21180BA3287EACEB005ED3AF /* Sound.swift in Sources */,
+				21ABB2F8287C665B00BE4117 /* ViewModelWatch.swift in Sources */,
+				211EA72C287A5FDA008BAD8D /* NotificationView.swift in Sources */,
+				211EA744287A6207008BAD8D /* Static.swift in Sources */,
+				21180BA2287EACE8005ED3AF /* MixedSound.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		58DE617B2839C13900F25769 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -484,6 +682,7 @@
 				58DE61BD283E542400F25769 /* MixedSoundCard.swift in Sources */,
 				58DE61C72843100100F25769 /* VolumeControl.swift in Sources */,
 				58DE61832839C13900F25769 /* LullabyRecipeApp.swift in Sources */,
+				21ABB2F6287C662F00BE4117 /* ViewModelPhone.swift in Sources */,
 				4A5769AC2866F20A007CCAE9 /* MixedSound.swift in Sources */,
 				58DE61B4283A8E4500F25769 /* Recipe.swift in Sources */,
 				58DE101C283CA87F002CDB9F /* SoundCard.swift in Sources */,
@@ -516,6 +715,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		211EA723287A5FDA008BAD8D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 211EA71F287A5FDA008BAD8D /* WatchLullabyRecipe WatchKit Extension */;
+			targetProxy = 211EA722287A5FDA008BAD8D /* PBXContainerItemProxy */;
+		};
+		211EA737287A5FDA008BAD8D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 211EA717287A5FD9008BAD8D /* WatchLullabyRecipe */;
+			targetProxy = 211EA736287A5FDA008BAD8D /* PBXContainerItemProxy */;
+		};
 		58DE61912839C13B00F25769 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 58DE617E2839C13900F25769 /* LullabyRecipe */;
@@ -529,6 +738,122 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		211EA73A287A5FDA008BAD8D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				GENERATE_INFOPLIST_FILE = YES;
+				IBSC_MODULE = WatchLullabyRecipe_WatchKit_Extension;
+				INFOPLIST_KEY_CFBundleDisplayName = WatchLullabyRecipe;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.leeo.LullabyRecipe;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Debug;
+		};
+		211EA73B287A5FDA008BAD8D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				GENERATE_INFOPLIST_FILE = YES;
+				IBSC_MODULE = WatchLullabyRecipe_WatchKit_Extension;
+				INFOPLIST_KEY_CFBundleDisplayName = WatchLullabyRecipe;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.leeo.LullabyRecipe;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Release;
+		};
+		211EA73D287A5FDA008BAD8D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"WatchLullabyRecipe WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = AJK25G55CT;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "WatchLullabyRecipe WatchKit Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "WatchLullabyRecipe WatchKit Extension";
+				INFOPLIST_KEY_CLKComplicationPrincipalClass = WatchLullabyRecipe_WatchKit_Extension.ComplicationController;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Debug;
+		};
+		211EA73E287A5FDA008BAD8D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"WatchLullabyRecipe WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = AJK25G55CT;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "WatchLullabyRecipe WatchKit Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "WatchLullabyRecipe WatchKit Extension";
+				INFOPLIST_KEY_CLKComplicationPrincipalClass = WatchLullabyRecipe_WatchKit_Extension.ComplicationController;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.LullabyRecipe.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Release;
+		};
 		58DE61A12839C13B00F25769 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -782,6 +1107,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		211EA73F287A5FDA008BAD8D /* Build configuration list for PBXNativeTarget "WatchLullabyRecipe WatchKit Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				211EA73D287A5FDA008BAD8D /* Debug */,
+				211EA73E287A5FDA008BAD8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		211EA740287A5FDA008BAD8D /* Build configuration list for PBXNativeTarget "WatchLullabyRecipe" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				211EA73A287A5FDA008BAD8D /* Debug */,
+				211EA73B287A5FDA008BAD8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		58DE617A2839C13900F25769 /* Build configuration list for PBXProject "LullabyRecipe" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/LullabyRecipe/Model/Sound.swift
+++ b/LullabyRecipe/Model/Sound.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+enum SoundType: String, Codable {
+    case base
+    case melody
+    case natural
+}
+
 struct Sound: Identifiable, Codable {
     let id: Int // = UUID()
     let name: String
@@ -15,18 +21,18 @@ struct Sound: Identifiable, Codable {
     let imageName: String
 }
 
-struct MixedSound: Identifiable, Codable, Equatable {
-    static func == (lhs: MixedSound, rhs: MixedSound) -> Bool {
-        return true
-    }
-    
-    let id: Int
-    let name: String
-    var baseSound: Sound?
-    var melodySound: Sound?
-    var naturalSound: Sound?
-    let imageName: String
-}
+//struct MixedSound: Identifiable, Codable, Equatable {
+//    static func == (lhs: MixedSound, rhs: MixedSound) -> Bool {
+//        return true
+//    }
+//
+//    let id: Int
+//    let name: String
+//    var baseSound: Sound?
+//    var melodySound: Sound?
+//    var naturalSound: Sound?
+//    let imageName: String
+//}
 
 var baseSounds = [
     Sound(id: 0,

--- a/LullabyRecipe/ViewModelPhone.swift
+++ b/LullabyRecipe/ViewModelPhone.swift
@@ -1,0 +1,44 @@
+//
+//  ViewModelPhone.swift
+//  LullabyRecipe
+//
+//  Created by Minkyeong Ko on 2022/07/11.
+//
+
+import Foundation
+import WatchConnectivity
+
+class ViewModelPhone: NSObject, WCSessionDelegate, ObservableObject {
+    
+    @Published var messageFromWatch = ""
+    
+    var session: WCSession
+    
+    init(session: WCSession = .default) {
+        self.session = session
+        super.init()
+        self.session.delegate = self
+        self.session.activate()
+    }
+    
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        DispatchQueue.main.async {
+            self.messageFromWatch = message["message"] as? String ?? "Unknown"
+        }
+    }
+    
+    // WCSessionDelegate를 만족하기 위한 함수 1
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        
+    }
+    
+    // WCSessionDelegate를 만족하기 위한 함수 2
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        
+    }
+    
+    // WCSessionDelegate를 만족하기 위한 함수 3
+    func sessionDidDeactivate(_ session: WCSession) {
+        
+    }
+}

--- a/LullabyRecipe/Views/Home/Home.swift
+++ b/LullabyRecipe/Views/Home/Home.swift
@@ -16,11 +16,22 @@ struct Home: View {
     
     @State var userRepositoriesState: [MixedSound] = userRepositories
     
+    var model = ViewModelPhone()
+
+    // Watch가 현재 Reachable 한지
+    @State var isWatchreachable = "No"
+
+    // 메시지를 보내기 위한 텍스트
+//    @State var messageText = "TestMessage"
+    @State var messageList: [String] = []
+    
+    
     var body : some View {
         ZStack {
             ColorPalette.background.color.ignoresSafeArea()
             
             VStack(spacing: 15) {
+                Text(model.messageFromWatch)
                 Profile()
                 
                 ScrollView(.vertical, showsIndicators: false) {
@@ -41,6 +52,11 @@ struct Home: View {
                     userRepositories = try decoder.decode([MixedSound].self, from: data)
                     print("help : \(userRepositories)")
                     userRepositoriesState = userRepositories
+                    
+                    self.model.session.sendMessage(["message" : userRepositoriesState.map{ [$0.name, $0.imageName] }], replyHandler: nil) { (error) in
+                        print(error.localizedDescription)
+                    }
+                    
                 } catch {
                     print("Unable to Decode Note (\(error))")
                 }
@@ -55,6 +71,11 @@ struct Home: View {
 
                     userRepositories = try decoder.decode([MixedSound].self, from: data)
                     userRepositoriesState = userRepositories
+                
+                    self.model.session.sendMessage(["message" : userRepositoriesState.map{ [$0.name, $0.imageName] }], replyHandler: nil) { (error) in
+                        print(error.localizedDescription)
+                    }
+                    
                     print("help : \(userRepositories)")
 
                 } catch {

--- a/LullabyRecipe/Views/Kitchen/Kitchen.swift
+++ b/LullabyRecipe/Views/Kitchen/Kitchen.swift
@@ -14,13 +14,6 @@ var categories = ["Natural",
                   "Lullaby"]
 
 
-
-enum SoundType: String, Codable {
-    case base
-    case melody
-    case natural
-}
-
 struct Kitchen : View {
  
     @State private var showingAlert = false

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "assets" : [
+    {
+      "filename" : "Circular.imageset",
+      "idiom" : "watch",
+      "role" : "circular"
+    },
+    {
+      "filename" : "Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "extra-large"
+    },
+    {
+      "filename" : "Graphic Bezel.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-bezel"
+    },
+    {
+      "filename" : "Graphic Circular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-circular"
+    },
+    {
+      "filename" : "Graphic Corner.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-corner"
+    },
+    {
+      "filename" : "Graphic Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-extra-large"
+    },
+    {
+      "filename" : "Graphic Large Rectangular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "filename" : "Modular.imageset",
+      "idiom" : "watch",
+      "role" : "modular"
+    },
+    {
+      "filename" : "Utilitarian.imageset",
+      "idiom" : "watch",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/ComplicationController.swift
+++ b/WatchLullabyRecipe WatchKit Extension/ComplicationController.swift
@@ -1,0 +1,59 @@
+//
+//  ComplicationController.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/10.
+//
+
+import ClockKit
+
+
+class ComplicationController: NSObject, CLKComplicationDataSource {
+    
+    // MARK: - Complication Configuration
+
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        let descriptors = [
+            CLKComplicationDescriptor(identifier: "complication", displayName: "LullabyRecipe", supportedFamilies: CLKComplicationFamily.allCases)
+            // Multiple complication support can be added here with more descriptors
+        ]
+        
+        // Call the handler with the currently supported complication descriptors
+        handler(descriptors)
+    }
+    
+    func handleSharedComplicationDescriptors(_ complicationDescriptors: [CLKComplicationDescriptor]) {
+        // Do any necessary work to support these newly shared complication descriptors
+    }
+
+    // MARK: - Timeline Configuration
+    
+    func getTimelineEndDate(for complication: CLKComplication, withHandler handler: @escaping (Date?) -> Void) {
+        // Call the handler with the last entry date you can currently provide or nil if you can't support future timelines
+        handler(nil)
+    }
+    
+    func getPrivacyBehavior(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void) {
+        // Call the handler with your desired behavior when the device is locked
+        handler(.showOnLockScreen)
+    }
+
+    // MARK: - Timeline Population
+    
+    func getCurrentTimelineEntry(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
+        // Call the handler with the current timeline entry
+        handler(nil)
+    }
+    
+    func getTimelineEntries(for complication: CLKComplication, after date: Date, limit: Int, withHandler handler: @escaping ([CLKComplicationTimelineEntry]?) -> Void) {
+        // Call the handler with the timeline entries after the given date
+        handler(nil)
+    }
+
+    // MARK: - Sample Templates
+    
+    func getLocalizableSampleTemplate(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationTemplate?) -> Void) {
+        // This method will be called once per supported complication, and the results will be cached
+        handler(nil)
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/ContentView.swift
+++ b/WatchLullabyRecipe WatchKit Extension/ContentView.swift
@@ -1,0 +1,35 @@
+//
+//  ContentView.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/10.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var selection = 0
+    
+    var body: some View {
+        
+        VStack {
+            TabView(selection: $selection) {
+                
+                ListView(selection: $selection)
+                    .tag(0)
+                PlayerView()
+                    .tag(1)
+            }
+            .tabViewStyle(PageTabViewStyle())
+            .animation(.easeInOut)
+            .transition(.slide)
+        }
+        
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Info.plist
+++ b/WatchLullabyRecipe WatchKit Extension/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>com.leeo.LullabyRecipe.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+</dict>
+</plist>

--- a/WatchLullabyRecipe WatchKit Extension/ListView.swift
+++ b/WatchLullabyRecipe WatchKit Extension/ListView.swift
@@ -1,0 +1,41 @@
+//
+//  ListView.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/13.
+//
+
+import SwiftUI
+
+struct ListView: View {
+    
+    @ObservedObject var model = ViewModelWatch()
+    
+    @Binding var selection: Int
+    
+    var body: some View {
+        
+        VStack {
+            List {
+                let _ = print(self.model.session.receivedApplicationContext)
+                ForEach(0..<self.model.messageList.count, id: \.self) { idx in
+                    Button (action: {
+                        selection = 1
+                    }) {
+                        HStack {
+                            Image(systemName: "play.circle")
+                            Text(self.model.messageList[idx][0])
+                        }
+                    }
+                }
+            }
+        }
+        
+    }
+}
+
+struct ListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ListView(selection: .constant(1))
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/LullabyRecipeApp.swift
+++ b/WatchLullabyRecipe WatchKit Extension/LullabyRecipeApp.swift
@@ -1,0 +1,27 @@
+//
+//  LullabyRecipeApp.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/10.
+//
+
+import SwiftUI
+
+@main
+struct LullabyRecipeApp: App {
+    @State private var selection = 0
+    
+    @SceneBuilder var body: some Scene {
+        WindowGroup {
+            
+            NavigationView {
+                
+                ContentView()
+                
+            }
+            
+        }
+
+        WKNotificationScene(controller: NotificationController.self, category: "myCategory")
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/NotificationController.swift
+++ b/WatchLullabyRecipe WatchKit Extension/NotificationController.swift
@@ -1,0 +1,33 @@
+//
+//  NotificationController.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/10.
+//
+
+import WatchKit
+import SwiftUI
+import UserNotifications
+
+class NotificationController: WKUserNotificationHostingController<NotificationView> {
+
+    override var body: NotificationView {
+        return NotificationView()
+    }
+
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+    override func didReceive(_ notification: UNNotification) {
+        // This method is called when a notification needs to be presented.
+        // Implement it if you use a dynamic notification interface.
+        // Populate your dynamic notification interface as quickly as possible.
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/NotificationView.swift
+++ b/WatchLullabyRecipe WatchKit Extension/NotificationView.swift
@@ -1,0 +1,20 @@
+//
+//  NotificationView.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/10.
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct NotificationView_Previews: PreviewProvider {
+    static var previews: some View {
+        NotificationView()
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/PlayerView.swift
+++ b/WatchLullabyRecipe WatchKit Extension/PlayerView.swift
@@ -1,0 +1,36 @@
+//
+//  PlayerView.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/13.
+//
+
+import SwiftUI
+
+struct PlayerView: View {
+    var body: some View {
+        HStack {
+            Button (action: {
+                
+            }) {
+                Image(systemName: "backward.fill")
+            }
+            Button (action: {
+                
+            }) {
+                Image(systemName: "play.fill")
+            }
+            Button (action: {
+                
+            }) {
+                Image(systemName: "forward.fill")
+            }
+        }
+    }
+}
+
+struct PlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerView()
+    }
+}

--- a/WatchLullabyRecipe WatchKit Extension/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/WatchLullabyRecipe WatchKit Extension/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WatchLullabyRecipe WatchKit Extension/PushNotificationPayload.apns
+++ b/WatchLullabyRecipe WatchKit Extension/PushNotificationPayload.apns
@@ -1,0 +1,20 @@
+{
+    "aps": {
+        "alert": {
+            "body": "Test message",
+            "title": "Optional title",
+            "subtitle": "Optional subtitle"
+        },
+        "category": "myCategory",
+        "thread-id": "5280"
+    },
+    
+    "WatchKit Simulator Actions": [
+        {
+            "title": "First Button",
+            "identifier": "firstButtonAction"
+        }
+    ],
+    
+    "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
+}

--- a/WatchLullabyRecipe WatchKit Extension/ViewModelWatch.swift
+++ b/WatchLullabyRecipe WatchKit Extension/ViewModelWatch.swift
@@ -1,0 +1,43 @@
+//
+//  ViewModelWatch.swift
+//  WatchLullabyRecipe WatchKit Extension
+//
+//  Created by Minkyeong Ko on 2022/07/11.
+//
+
+import Foundation
+import WatchConnectivity
+
+class ViewModelWatch: NSObject, WCSessionDelegate, ObservableObject {
+    
+    var session: WCSession
+    
+    @Published var messageList: [[String]] = [["", ""]]
+    
+    init(session: WCSession = .default) {
+        self.session = session
+        super.init()
+        self.session.delegate = self
+        self.session.activate()
+    }
+    
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        
+    }
+    
+    // 메시지를 받으면 트리거되는 함수
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        DispatchQueue.main.async {
+            print("메시지 받음")
+            self.messageList = message["message"] as? [[String]] ?? [["unknown", "hey"]]
+            print(self.messageList)
+        }
+    }
+    
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        print("application context 받음")
+        DispatchQueue.main.async {
+            self.messageList = applicationContext["message"] as? [[String]] ?? [["unknown", "hey"]]
+        }
+    }
+}

--- a/WatchLullabyRecipe/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/WatchLullabyRecipe/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WatchLullabyRecipe/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/WatchLullabyRecipe/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,109 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "33x33",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "46x46",
+      "subtype" : "41mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "51x51",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "117x117",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WatchLullabyRecipe/Assets.xcassets/Contents.json
+++ b/WatchLullabyRecipe/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- 프로젝트에 watchOS 타겟 추가
- 아이폰과 워치 사이에 메시지를 주고받는 로직을 테스트
- watch에 띄우는 리스트 화면 (`ListView`), 플레이어 화면 (`PlayerView`) 생성

## 기타 사항 (Etc)
- 현재는 워치가 아이폰과 페어링 되어 있고, 워치가 켜져 있는 상태에서 아이폰 앱을 들어가야 워치의 리스트가 업데이트 됩니다
- `sendMessage` 메소드에는 커스텀 타입이 들어갈 수가 없어서 `MixedSound`가 들어있는 배열을 직접 보내지 않고 name과 imageName만 전송하여 리스트를 띄웠는데, 추후 이미지나 기타 데이터를 보내기 위해서는 다른 메소드를 사용해야 할 것 같습니다 (이슈 이름이 데이터 주고받기라고 되어 있지만 사실상 메시지를 주고받는 테스트를 진행하였습니다)
- 백그라운드에서 데이터를 수신하는 코드를 테스트 할 방법을 아직 찾지 못하였습니다. 계속 찾아보겠지만 혹시 아시는 분이 있다면 알려주시면 감사하겠습니다.

## Close Issues
Close #44 

## 관련 사진(Optional)
![gif_issue_44](https://user-images.githubusercontent.com/78426896/178993527-e17c3421-c7e9-4053-bb5f-c2c5b4357922.gif)

