### PR TITLE
docs: README에 지원 페이지·법적 고지 링크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ MVVM
 - SwiftUI
 - Combine
 - AVFoundation
+
+## Support & Legal 📄
+- 지원 페이지 / Support: https://m1zz.github.io/RelaxOn/
+- 개인정보 처리방침 / Privacy Policy: https://m1zz.github.io/RelaxOn/privacy.html
+- 이용약관 / Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+- 문의 / Contact: mizzking75@gmail.com


### PR DESCRIPTION
## 요약
저장소 홈(기본 브랜치 `main`)의 README에 GitHub Pages 지원 페이지 및 법적 고지 링크가 보이도록 `Support & Legal` 섹션을 추가합니다. (해당 섹션은 `dev`에는 이미 있었음)

## 추가되는 링크
- 지원 페이지 / Support: https://m1zz.github.io/RelaxOn/
- 개인정보 처리방침 / Privacy Policy: https://m1zz.github.io/RelaxOn/privacy.html
- 이용약관 / Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
- 문의 / Contact: mizzking75@gmail.com

## 참고
- 지원 페이지는 이미 `main/docs`에서 빌드되어 라이브 상태(HTTP 200)입니다. 본 PR은 README 링크 노출만 반영합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)